### PR TITLE
Removing a Duplicate Tract Function

### DIFF
--- a/surgeo/models/base_model.py
+++ b/surgeo/models/base_model.py
@@ -78,14 +78,6 @@ class BaseModel(object):
         ).set_index(['state','county','tract'])
         return prob_race_given_tract
 
-    def _get_prob_tract_given_race(self):
-        prob_tract_given_race = pd.read_csv(
-            self._package_root / 'data' / 'prob_tract_given_race_2010.csv',
-            na_values=[''],
-            keep_default_na=False,
-            dtype={'state':str,'county':str,'tract':str}
-        ).set_index(['state','county','tract'])
-        return prob_tract_given_race
 
     def _get_prob_zcta_given_race(self):
         """Create dataframe of ZCTA ratios given a race (for SurGeo)"""

--- a/surgeo/models/surgeo_model.py
+++ b/surgeo/models/surgeo_model.py
@@ -136,8 +136,9 @@ class SurgeoModel(BaseModel):
                       surgeo_probs: pd.DataFrame) -> pd.DataFrame:
         # Build frame from zctas, names, and probabilities
         if self.geo_level == 'TRACT':
-            surgeo_data = pd.concat([geo_probs, 
-                sur_probs['name'].to_frame()
+            surgeo_data = pd.concat([geo_probs[['state','county','tract']], 
+                sur_probs['name'].to_frame(),
+                surgeo_probs
             ], axis=1)
         else:
             surgeo_data = pd.concat([

--- a/surgeo/models/surgeo_model.py
+++ b/surgeo/models/surgeo_model.py
@@ -72,7 +72,7 @@ class SurgeoModel(BaseModel):
         super().__init__()
         self.geo_level = geo_level.upper()
         if geo_level == "TRACT":
-            self._PROB_GEO_GIVEN_RACE = self._get_prob_tract_given_race()
+            self._PROB_GEO_GIVEN_RACE = self._get_prob_race_given_tract()
         else:
             self._PROB_GEO_GIVEN_RACE = self._get_prob_zcta_given_race()
         self._PROB_RACE_GIVEN_SURNAME = self._get_prob_race_given_surname()


### PR DESCRIPTION
In real world use, the `Surgeo` model wasn't giving any strong results even though the geocode and surname models seemed to be working fine. 

There seems to be an inconsistency in two similarly named functions so this cleans that up and corrects the errors. 